### PR TITLE
fixed auth0 error by changing redirect URL

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -102,15 +102,16 @@ angular.module('avalancheCanadaApp', [
               store.set('token', idToken);
             });
 
+            $location.url('/submit');
             // if we use the state service to go to the ac.submit state
             // it doesn't remove the #access_token=... part of the url that comes back from auth0
-            var loginRedirectUrl = store.get('loginRedirectUrl');
+            /*var loginRedirectUrl = store.get('loginRedirectUrl');
             if(loginRedirectUrl) {
                 $location.url(loginRedirectUrl);
                 store.remove('loginRedirectUrl');
             } else {
                 $location.url('/');
-            }
+            }*/
         }
 
         onLoginSucccess.$inject = ['$location', 'profilePromise', 'idToken', 'store', '$state', '$urlRouter'];


### PR DESCRIPTION
auth0 has a list of allowed redirect URLS, yet the app was trying to redirect the user to whcihever page they where currently on. We cannot add every page to the allowed list. Instead made it so that logging in sucesfully takes the user to the submit page