### PR TITLE
My suggested changes

### DIFF
--- a/server/api/observations/index.js
+++ b/server/api/observations/index.js
@@ -24,10 +24,11 @@ router.post('/submissions', function(req, res) {
                 error: 'There was an error while saving your submission.',
             });
         } else {
-            request('https://api-dev.avalanche.ca/min/migrate/' + obs.subid, (err, res, body) => {
-                if (err) { return console.log(err); }
-                    logger.error('error migrating submission: %s', err)
-                });
+            request(process.env.API_URL + '/min/migrate/' + obs.subid, function(err) {
+                if (err) { 
+                    logger.error('error migrating submission: %s', err);
+                }
+            });
               
             res.json(201, obs);
         }


### PR DESCRIPTION
- Removed `console.log` to avoid bloating the console especially when there are circular references. Yep, it happens to code I pushed before...🥇 to Karl!  
- Changed arrow function to an old school function. I have been a bit paranoid about using the oldest Javascript features on that old server
- Reworked the `if` statement for the `err`: `logger.error` was called all the time
- Added an ENV variable, deployment could be easier this way